### PR TITLE
Add defview configuration options and wrapper view option for render

### DIFF
--- a/src/main/workflo/macros/view.cljs
+++ b/src/main/workflo/macros/view.cljs
@@ -1,3 +1,36 @@
 (ns workflo.macros.view
   (:require [om.next]
             [om.dom]))
+
+;;;; Configuration
+
+(def +configuration+
+  "Configuration options for the defview macro."
+  (atom {:wrapper-view nil}))
+
+(defn configure!
+  "Configures the defview macro, usually before it is being used.
+   Supports the following options:
+
+   :wrapper-view - a React element factory to use for wrapping
+                   the body of render functions if render has
+                   more than a single child expression."
+  [{:keys [wrapper-view] :as options}]
+  (swap! +configuration+ assoc
+         :wrapper-view wrapper-view))
+
+(defn get-config
+  "Returns the configuration for a given configuration key, e.g.
+   :wrapper-view."
+  [key]
+  (@+configuration+ key))
+
+(defn wrapper
+  "Returns a wrapper factory for use in render functions. If no
+   wrapper function is defined, issues a warning and returns
+   om.dom/div to avoid breaking apps entirely."
+  []
+  (if-not (get-config :wrapper-view)
+    (do (js/console.warning "No wrapper view defined for defview.")
+        om.dom/div)
+    (get-config :wrapper-view)))

--- a/src/test/workflo/macros/view_test.cljs
+++ b/src/test/workflo/macros/view_test.cljs
@@ -1,7 +1,6 @@
 (ns workflo.macros.view-test
   (:require [cljs.test :refer-macros [deftest is]]
-            [om.next :as om]
-            [workflo.macros.view :refer-macros [defview]]))
+            [workflo.macros.view :as view :refer-macros [defview]]))
 
 (deftest minimal-view-definition
   (is (= (macroexpand-1
@@ -125,5 +124,28 @@
               (on-click [this]
                 (let [{:keys [user/name]} (om/props this)]
                   (js/alert name))))
+            (def view
+              (om.next/factory View {}))))))
+
+(defview Wrapper
+  (render
+    (om.dom/div nil
+      (om.next/children this))))
+
+(deftest view-definition-with-wrapper-and-multiple-render-children
+  (view/configure! {:wrapper-view wrapper})
+  (is (= (macroexpand-1
+          '(defview View
+             (render
+               (foo)
+               (bar))))
+         '(do
+            (om.next/defui View
+              Object
+              (render [this]
+                ((workflo.macros.view/wrapper)
+                  (om.next/props this)
+                  (foo)
+                  (bar))))
             (def view
               (om.next/factory View {}))))))


### PR DESCRIPTION
This wrapper view allows to define render functions that return
multiple child expressions. Since React requires render to return
a single element, defview will now automatically wrap multiple child
expressions in a wrapper view (defaulting to om.dom/div). So

```
(render [this]
  (foo)
  (bar))
```

will be turned into

```
(render [this]
  ((workflo.macros.wrapper) (om/props this)
    (foo)
    (bar)))
```

This commits also adds a basic code generation test for this.
