### PR TITLE
Don't require defcommand implementation body to be a list/seq

### DIFF
--- a/src/main/workflo/macros/command.clj
+++ b/src/main/workflo/macros/command.clj
@@ -97,7 +97,7 @@
          data-spec   (second (last inputs))
          name-sym    (util/unqualify name)
          all-forms   (conj forms {:form-name 'implementation
-                                  :form-body impl})
+                                  :form-body (list impl)})
          form-fns    (->> all-forms
                           (map #(update % :form-name
                                         util/prefix-form-name

--- a/src/main/workflo/macros/specs/command.cljc
+++ b/src/main/workflo/macros/specs/command.cljc
@@ -37,7 +37,7 @@
                  :form-body ::command-form-body)))
 
 (s/def ::command-implementation
-  seq?)
+  ::s/any)
 
 (s/def ::defcommand-args
   (s/cat :name ::command-name

--- a/src/test/workflo/macros/command_test.clj
+++ b/src/test/workflo/macros/command_test.clj
@@ -7,7 +7,7 @@
   (is (= '(do
             (defn user-create-implementation
               [query-result data]
-              :foo :bar)
+              (:foo :bar))
             (def user-create-data-spec
               vector?)
             (def user-create-definition
@@ -33,7 +33,7 @@
                :implementation pod/user-update-implementation}))
          (macroexpand-1 `(defcommand user/update [~'[user [name email]]
                                                   ~'vector?]
-                           ({:some :data}))))))
+                           {:some :data})))))
 
 (deftest defcommand-with-forms
   (is (= '(do
@@ -51,7 +51,7 @@
                :data-spec pod/user-update-data-spec}))
          (macroexpand-1 `(defcommand user/update [~'vector?]
                            (~'foo [:bar])
-                           ({:implementation :result}))))))
+                           {:implementation :result})))))
 
 (deftest defcommand-with-cache-query-and-forms
   (is (= '(do
@@ -74,7 +74,7 @@
                :data-spec pod/user-create-data-spec}))
          (macroexpand-1 `(defcommand user/create [~'[db [id]] ~'map?]
                            (~'foo [:bar])
-                           (:result))))))
+                           :result)))))
 
 ;;;; Exercise run-command
 
@@ -97,7 +97,7 @@
 
 (defcommand user/create
   [[db [id]] ::user-create-data]
-  ({:cache {:db-id id}}))
+  {:cache {:db-id id}})
 
 (c/configure! {:query example-query
                :process-result example-process-result})


### PR DESCRIPTION
This allows to write defcommand like a function

  (defcommand my/command
    [<query> <spec>]
    {:result-key :result-value})

or

  (defcommand my/command
    [<query> <spec>](let [foo :bar]
      foo))

rather than having to write

  (defcommand my/command
    [...](%28let [foo :bar]
       foo%29))

Arbitrary command-prefixed functions can still be declared as
before:

  (defcommand my/command
    [...](foo :bar)
    :some-result))
