### PR TITLE
Resolve command query params using command data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # CHANGELOG workflo/macros
 
+## Unreleased
+
+### Added
+
+* Function to bind query parameters using a parameter/value
+  map: `workflo.macros.query/bind-query-parameters`.
+
 ## 0.2.7
 
-## Changed
+### Changed
 
 * Change notation for defcommand implementation forms by no
   longe requiring a sequence/list expression.

--- a/src/main/workflo/macros/command.clj
+++ b/src/main/workflo/macros/command.clj
@@ -64,7 +64,8 @@
       (assert (s/valid? (:data-spec definition) data)
               (str "Command data is invalid:"
                    (s/explain-str (:data-spec definition) data))))
-    (let [cache-query    (some-> definition :cache-query)
+    (let [cache-query    (some-> definition :cache-query
+                                 (q/bind-query-parameters data))
           query-result   (some-> (get-config :query)
                                  (apply [cache-query]))
           command-result ((:implementation definition)

--- a/src/main/workflo/macros/query.cljc
+++ b/src/main/workflo/macros/query.cljc
@@ -142,3 +142,37 @@
    properties specification."
   [props]
   (into [] (map :name) props))
+
+(s/fdef bind-query-parameters
+  :args (s/cat :query :workflo.macros.specs.parsed-query/query
+               :params map?)
+  :ret  :workflo.macros.specs.parsed-query/query)
+
+(defn bind-query-parameters
+  "Takes a parsed query and a map of named parameters and their
+   values. Binds the unbound parameters in the query (that is,
+   those where the value is a symbol beginning with a ?) to
+   values of the corresponding parameters in the parameter map
+   and returns the result.
+
+   As an example, the :db/id parameter in the query
+
+     [{:name user :type :join
+       :join-target [{:name name :type :property}]
+       :parameters {:db/id ?foo}}]
+
+   would be bound to the value 10 if the parameter map was
+   {:foo 10}."
+  [query params]
+  (letfn [(bind-param [[k v]]
+            (let [vname (when (symbol? v) (str v))]
+              [k (if (= \? (first vname))
+                   (params (keyword (subs vname 1)))
+                   v)]))
+          (bind-params [unbound-params]
+            (into {} (map bind-param) unbound-params))
+          (bind-query-parameters* [subquery]
+            (if (contains? subquery :parameters)
+              (update subquery :parameters bind-params)
+              subquery))]
+    (mapv bind-query-parameters* query)))


### PR DESCRIPTION
One problem this does not solve yet is that the command data may be deeply nested, while we assume the parameter map that is used for resolving to be flat.
