### PR TITLE
Bind non-namespaced parameter vars to namespaced keys as a fallback

### DIFF
--- a/src/main/workflo/macros/query.cljc
+++ b/src/main/workflo/macros/query.cljc
@@ -172,12 +172,22 @@
           (path? [x]
             (and (vector? x)
                  (every? var? x)))
+          (denamespace-keys [m]
+            (if (map? m)
+              (zipmap (map (comp keyword name) (keys m))
+                      (vals m))
+              m))
+          (resolve-var [vname params]
+            (let [kw (keyword vname)]
+              (or (get params kw)
+                  (when (nil? (namespace kw))
+                    (get (denamespace-keys params) kw)))))
           (bind-path [path params]
             (loop [path path params params]
               (let [[var & remainder] path
                     vname (when (var? var)
                             (subs (str var) 1))]
-                (let [val (get params (keyword vname))]
+                (let [val (resolve-var vname params)]
                   (if (empty? remainder)
                     val
                     (recur remainder val))))))


### PR DESCRIPTION
This allows to bind `[?foo ?bar]` to e.g. `{:x/foo {:y/bar <val>}}` and makes the notation for parameterizing against deeply nested parameter maps even more compact than it already is.
