### PR TITLE
Fix how defjscomponents resolves JS component definitions

### DIFF
--- a/src/main/workflo/macros/jscomponents.clj
+++ b/src/main/workflo/macros/jscomponents.clj
@@ -6,12 +6,12 @@
 
 (defn defjscomponent*
   [module name]
-  (let [fn-sym (symbol (camel->kebab name))
-        js-sym (symbol "js" (str module "." name))]
+  (let [fn-sym     (symbol (camel->kebab name))
+        module-sym (symbol "js" (str module))]
     `(defn ~fn-sym [props# & children#]
        (.apply ~(symbol "js" "React.createElement") nil
                (into-array
-                (cons ~js-sym
+                (cons (~'aget ~module-sym ~(str name))
                       (cons (~'clj->js props#)
                             children#)))))))
 


### PR DESCRIPTION
This is necessary for the component factory functions created by
defjscomponents to work with CLJS advanced optimizations. The trick
here is to use (aget <JS module> <component name>) instead of
js/<JS module>.<component name>.
