### PR TITLE
Add a camelize-keys function and use it in defjscomponents

### DIFF
--- a/src/main/workflo/macros/jscomponents.clj
+++ b/src/main/workflo/macros/jscomponents.clj
@@ -4,6 +4,8 @@
             [clojure.string :as str]
             [workflo.macros.util.string :refer [camel->kebab]]))
 
+(def camelize-keys workflo.macros.util.string/camelize-keys)
+
 (defn defjscomponent*
   [module name]
   (let [fn-sym     (symbol (camel->kebab name))
@@ -12,7 +14,9 @@
        (.apply ~(symbol "js" "React.createElement") nil
                (into-array
                 (cons (~'aget ~module-sym ~(str name))
-                      (cons (~'clj->js props#)
+                      (cons (-> props#
+                                workflo.macros.jscomponents/camelize-keys
+                                ~'clj->js)
                             children#)))))))
 
 (defn defjscomponents*

--- a/src/main/workflo/macros/util/string.cljc
+++ b/src/main/workflo/macros/util/string.cljc
@@ -1,6 +1,7 @@
 (ns workflo.macros.util.string
   (:require [clojure.spec :as s]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [clojure.walk :refer [walk]]))
 
 (s/fdef camel->kebab
   :args (s/cat :s string?)
@@ -27,3 +28,14 @@
     (apply str
            (cons (first words)
                  (map string/capitalize (rest words))))))
+
+(defn camelize-keys
+  "Convert a Clojure map to a map where all keys are
+   camel-cased strings that can be accessed like object
+   properties in JS/React."
+  [m]
+  (walk (fn [[k v]]
+          [(kebab->camel (name k))
+           (cond-> v (map? v) camelize-keys)])
+        identity
+        m))


### PR DESCRIPTION
This recursively translates view properties from ClojureScript to
maps with camel-cased keys that we can pass on to JS components
and have them be able to acess keys like :foo-bar as fooBar.
