### PR TITLE
Support fully qualified commands to be bound in views

### DIFF
--- a/src/main/workflo/macros/view.clj
+++ b/src/main/workflo/macros/view.clj
@@ -188,7 +188,9 @@
   (if-not (= :static (fn-scope f))
     (let [this-index   (.indexOf form-args 'this)
           cmd-bindings (when (>= this-index 0)
-                         (apply concat (into [] command-fns)))]
+                         (mapcat (fn [[cmd-name cmd-fn]]
+                                   [(symbol (name cmd-name)) cmd-fn])
+                                 command-fns))]
       (cond-> f
         (not (empty? cmd-bindings))
         (assoc :form-body

--- a/src/test/workflo/macros/view_test.cljs
+++ b/src/test/workflo/macros/view_test.cljs
@@ -194,7 +194,7 @@
 (deftest view-with-commands
   (is (= (macroexpand-1
           '(defview View
-             (commands [goto show-foo])
+             (commands [ui/goto show-foo])
              (render
               (foo {:on-click #(goto 'some-screen {:id 1})}))))
          '(do
@@ -203,7 +203,7 @@
               (render [this]
                 (let [goto     (fn [params & reads]
                                  (workflo.macros.view/run-command!
-                                  'goto this params reads))
+                                  'ui/goto this params reads))
                       show-foo (fn [params & reads]
                                  (workflo.macros.view/run-command!
                                   'show-foo this params reads))]


### PR DESCRIPTION
A commands form like

    (commands [ui/foo foo/baz])

would then make the functions available in e.g. render as foo and
baz.