### PR TITLE
Add :workflo.macros.specs.types/impersistent hint for entity attributes

### DIFF
--- a/src/main/workflo/macros/entity/schema.cljc
+++ b/src/main/workflo/macros/entity/schema.cljc
@@ -57,7 +57,10 @@
     :workflo.macros.specs.types/indexed [:indexed]
     :workflo.macros.specs.types/fulltext [:fulltext]
     :workflo.macros.specs.types/no-history [:nohistory]
-    :workflo.macros.specs.types/component [:component]))
+    :workflo.macros.specs.types/component [:component]
+
+    ;; Impersistent types
+    :workflo.macros.specs.types/impersistent []))
 
 (defn enum-values-from-and-spec
   [spec]
@@ -202,6 +205,33 @@
 (defn optional-keys
   [entity]
   (or (:optional (keys entity)) []))
+
+;;;; Impersistent keys
+
+(defn impersistent-type-spec?
+  [spec]
+  (= spec :workflo.macros.specs.types/impersistent))
+
+(defn impersistent-and-key-spec?
+  [spec]
+  (when-let [type-specs (filter type-spec? spec)]
+    (some impersistent-type-spec? type-specs)))
+
+(defn impersistent-key-spec?
+  [spec]
+  (cond
+    (and-spec? spec) (impersistent-and-key-spec? spec)
+    (type-spec? spec) (impersistent-type-spec? spec)
+    :else false))
+
+(defn impersistent-key?
+  [key]
+  (impersistent-key-spec? (s/describe (s/get-spec key))))
+
+(defn impersistent-keys
+  [entity]
+  (into [] (filter impersistent-key?)
+        (apply concat (vals (keys entity)))))
 
 ;;;; Entity ref(erences)
 

--- a/src/main/workflo/macros/specs/types.cljc
+++ b/src/main/workflo/macros/specs/types.cljc
@@ -102,3 +102,7 @@
 (s/def ::fulltext any?)
 (s/def ::component any?)
 (s/def ::no-history any?)
+
+;;;; Types whose values are not to be persisted
+
+(s/def ::impersistent any?)

--- a/src/test/workflo/macros/entity/schema_test.cljc
+++ b/src/test/workflo/macros/entity/schema_test.cljc
@@ -101,6 +101,16 @@
     [:user/bio
      :user/address] 'user-with-extended-spec))
 
+;;;; Impersistent keys
+
+(deftest impersistent-keys
+  (are [x y] (= x (-> y resolve-entity schema/impersistent-keys))
+    [] 'url/selected-user
+    [] 'ui/search-text
+    [] 'ui/search-text-with-extended-spec
+    [] 'user
+    [:user/address] 'user-with-extended-spec))
+
 ;;;; Entity refs
 
 ;;; Entities with refs between them

--- a/src/test/workflo/macros/entity/test_entities.cljc
+++ b/src/test/workflo/macros/entity/test_entities.cljc
@@ -27,7 +27,7 @@
    (s/keys :req [:base/id :user/name :user/email :user/role]
            :opt [:user/bio])))
 
-(s/def :user/address ::types/string)
+(s/def :user/address (s/and ::types/string ::types/impersistent))
 
 (defentity user-with-extended-spec
   (spec


### PR DESCRIPTION
This hint can be set on any entity attribute to e.g. prevent the attribute
from being persistent into databases.