### PR TITLE
Fix merging command data and context prior to binding query params

### DIFF
--- a/src/main/workflo/macros/command.clj
+++ b/src/main/workflo/macros/command.clj
@@ -64,7 +64,9 @@
        (assert (s/valid? (:spec definition) data)
                (str "Command data is invalid:"
                     (s/explain-str (:spec definition) data))))
-     (let [bind-data         (merge context data)
+     (let [bind-data         (if (map? data)
+                               (merge context data)
+                               (merge context {:data data}))
            query-result      (when-let [query-hook (get-command-config :query)]
                                (some-> (:query definition)
                                        (q/bind-query-parameters bind-data)

--- a/src/main/workflo/macros/command.cljs
+++ b/src/main/workflo/macros/command.cljs
@@ -61,7 +61,9 @@
        (assert (s/valid? (:spec definition) data)
                (str "Command data is invalid:"
                     (s/explain-str (:spec definition) data))))
-     (let [bind-data         (merge context data)
+     (let [bind-data         (if (map? data)
+                               (merge context data)
+                               (merge context {:data data}))
            query-result      (when-let [query-hook (get-command-config :query)]
                                (some-> (:query definition)
                                        (q/bind-query-parameters bind-data)


### PR DESCRIPTION
If data is not a map, it is now inserted into a map under the :data
key so that queries can bind to it in parameters via ?data.

The previous approach would throw an error because merge does not
accept non-sequential arguments.