### PR TITLE
defservice: Add a :debounced-by-data hint for services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG workflo/macros
 
+## 0.2.??
+
+### Added
+
+* Add a `:debounced-by-data` hint for debouncing service deliveries
+  with the same data/payload.
+
 ## 0.2.55
 
 ### Changed


### PR DESCRIPTION
This allows to group and debounce deliveries to a service with the
same input data. E.g. two consecutive events with data :foo for the
same service will only result in a single delivery to the service,
if the events happen within 1000ms.